### PR TITLE
Add FastAPI backend and tasks UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Python
+__pycache__/
+*.py[cod]
+*.db

--- a/README.md
+++ b/README.md
@@ -1,10 +1,36 @@
-# Schedasito React App
+# Schedasito Platform
 
-This project was bootstrapped with **Vite** and rewritten using React functional components.
-Temporary data is loaded from JSON files inside `public/data/` and can be replaced with real API endpoints later.
+This repository contains a minimal full stack implementation for managing website projects. The frontend is built with **React** + **Vite** and the backend uses **FastAPI** with **SQLModel**.
+
+## Backend
+
+1. Install dependencies:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+2. Run the API server:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+The API exposes `/projects/` and `/tasks/` endpoints backed by a SQLite database populated with sample data on startup.
+
+## Frontend
+
+1. Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+The frontend expects the API to run on `http://localhost:8000`. You can change the base URL by defining the `VITE_API_URL` environment variable.
 
 ## Available Scripts
 
 - `npm run dev` – start the development server with hot reload.
 - `npm run build` – create a production build in the `dist` folder.
-
+- `npm run lint` – run ESLint.

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from sqlmodel import SQLModel, Session, create_engine, select
+
+from .models import Project, Task
+
+sqlite_url = "sqlite:///./database.db"
+engine = create_engine(sqlite_url, echo=False)
+
+
+def init_db() -> None:
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        if not session.exec(select(Project)).first():
+            session.add_all(
+                [Project(name="Progetto Alpha"), Project(name="Progetto Beta")]
+            )
+            session.commit()
+        if not session.exec(select(Task)).first():
+            session.add_all(
+                [
+                    Task(title="Task iniziale", project_id=1),
+                    Task(title="Secondo Task", project_id=2),
+                ]
+            )
+            session.commit()
+
+
+def get_session() -> Session:
+    with Session(engine) as session:
+        yield session

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import Depends, FastAPI
+from sqlmodel import Session, select
+
+from .database import get_session, init_db
+from .models import Project, Task
+
+app = FastAPI(title="SchedaSito API")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+
+
+@app.get("/projects/", response_model=List[Project])
+def read_projects(session: Session = Depends(get_session)) -> List[Project]:
+    return session.exec(select(Project)).all()
+
+
+@app.post("/projects/", response_model=Project)
+def create_project(
+    project: Project, session: Session = Depends(get_session)
+) -> Project:
+    session.add(project)
+    session.commit()
+    session.refresh(project)
+    return project
+
+
+@app.get("/tasks/", response_model=List[Task])
+def read_tasks(session: Session = Depends(get_session)) -> List[Task]:
+    return session.exec(select(Task)).all()
+
+
+@app.post("/tasks/", response_model=Task)
+def create_task(task: Task, session: Session = Depends(get_session)) -> Task:
+    session.add(task)
+    session.commit()
+    session.refresh(task)
+    return task
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Optional
+from sqlmodel import Field, SQLModel
+
+
+class Project(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+
+
+class Task(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    project_id: int = Field(foreign_key="project.id")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+sqlmodel

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,17 @@
 import { Suspense, lazy } from 'react';
 import { Routes, Route } from 'react-router-dom';
+import NavBar from './components/NavBar';
 
 const HomePage = lazy(() => import('./pages/HomePage'));
+const TasksPage = lazy(() => import('./pages/TasksPage'));
 
 function App() {
   return (
     <Suspense fallback={<div>Loading...</div>}>
+      <NavBar />
       <Routes>
         <Route path="/" element={<HomePage />} />
+        <Route path="/tasks" element={<TasksPage />} />
       </Routes>
     </Suspense>
   );

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom';
+
+function NavBar() {
+  return (
+    <nav className="p-4 bg-gray-800 text-white flex gap-4">
+      <Link to="/">Progetti</Link>
+      <Link to="/tasks">Task</Link>
+    </nav>
+  );
+}
+
+export default NavBar;

--- a/src/components/TasksList.jsx
+++ b/src/components/TasksList.jsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { fetchTasks } from '../services/api';
+
+function TasksList() {
+  const [tasks, setTasks] = useState([]);
+
+  useEffect(() => {
+    fetchTasks().then(setTasks).catch(console.error);
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-4">Lista Task</h2>
+      <ul className="space-y-2">
+        {tasks.map((task) => (
+          <li key={task.id} className="p-2 bg-gray-100 rounded">
+            {task.title}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default TasksList;

--- a/src/pages/TasksPage.jsx
+++ b/src/pages/TasksPage.jsx
@@ -1,0 +1,9 @@
+import TasksList from '../components/TasksList';
+
+const TasksPage = () => (
+  <div className="container mx-auto mt-4">
+    <TasksList />
+  </div>
+);
+
+export default TasksPage;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,17 @@
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
 export async function fetchProjects() {
-  const response = await fetch('/data/projects.json');
+  const response = await fetch(`${API_URL}/projects/`);
   if (!response.ok) {
     throw new Error('Failed to load projects');
+  }
+  return response.json();
+}
+
+export async function fetchTasks() {
+  const response = await fetch(`${API_URL}/tasks/`);
+  if (!response.ok) {
+    throw new Error('Failed to load tasks');
   }
   return response.json();
 }


### PR DESCRIPTION
## Summary
- implement FastAPI backend with SQLite database for projects and tasks
- update React app to consume API and add tasks navigation
- document backend and frontend usage in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846a49a47f4832a95478f8905089de4

## Summary by Sourcery

Add a minimal full-stack implementation by introducing a FastAPI backend with SQLite persistence and exposing projects and tasks endpoints, updating the React app to consume the API and provide a tasks UI, and documenting setup in the README

New Features:
- Add FastAPI backend with SQLite-powered /projects/ and /tasks/ REST endpoints
- Integrate React frontend to fetch projects and tasks from the API
- Implement Tasks page and navigation bar in the React app

Enhancements:
- Switch data loading from static JSON files to API fetches
- Allow customizing API base URL via VITE_API_URL

Documentation:
- Add backend and frontend setup instructions to the README